### PR TITLE
Fix check for being ECS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: aws.ec2metadata
 Type: Package
 Title: Get EC2 Instance Metadata
-Version: 0.1.5
+Version: 0.1.6
 Date: 2018-07-26
 Authors@R: c(person("Thomas J.", "Leeper", role = c("aut"),
                     email = "thosjleeper@gmail.com",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,4 +16,4 @@ BugReports: https://github.com/cloudyr/aws.ec2metadata/issues
 Imports:
     curl,
     jsonlite
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1

--- a/R/aws.ec2metadata-package.R
+++ b/R/aws.ec2metadata-package.R
@@ -55,7 +55,7 @@ instance_document <- function() {
 }
 
 #' @rdname ec2metadata
-#' @details \code{is_ec2} returns a logical for whether the current R session appears to be running in an EC2 instance.
+#' @details \code{is_ec2()} returns a logical for whether the current R session appears to be running in an EC2 instance. \code{is_ecs()} returns a logical for whether the current R session appears to be running in an ECS task container.
 #' 
 #' \code{instance_document} returns a list containing values from the \href{http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html}{Instance Identity Document}, including the instance ID, AMI ID, region, availability zone, etc.
 #' 
@@ -65,7 +65,7 @@ instance_document <- function() {
 #'
 #' The remaining functions in the list are aliases for potentially commonly needed metadata items.
 #' 
-#' @return \code{is_ec2} returns a logical. Generally, all other functions will return a character string containing the requested information, otherwise a \code{NULL} if the response is empty. The \code{iam_role()} function returns a list. An error will occur if, for some reason, the request otherwise fails.
+#' @return \code{is_ec2()} and \code{is_ecs()} return a logical. Generally, all other functions will return a character string containing the requested information, otherwise a \code{NULL} if the response is empty. The \code{iam_role()} and \code{ecs_metadata()} functions return a list. An error will occur if, for some reason, the request otherwise fails.
 #' @examples
 #' names(metadata)
 #' 

--- a/R/aws.ec2metadata-package.R
+++ b/R/aws.ec2metadata-package.R
@@ -189,9 +189,9 @@ is_ecs <- function() {
 
 #' @rdname ec2metadata
 #' @export
-ecs_metadata <- function() {
+ecs_metadata <- function(base_url="http://169.254.170.2") {
     container_relative <- Sys.getenv(ENV_CONTAINER_CREDS)
-    uri <- paste0("http://169.254.170.2", container_relative)
+    uri <- paste0(base_url, container_relative)
     response <- try(curl::curl_fetch_memory(uri), silent = TRUE)
     if (inherits(response, "try-error")) {
         out <- NULL

--- a/R/aws.ec2metadata-package.R
+++ b/R/aws.ec2metadata-package.R
@@ -188,6 +188,7 @@ is_ecs <- function() {
 }
 
 #' @rdname ec2metadata
+#' @param base_url Base URL for querying instance metadata
 #' @export
 ecs_metadata <- function(base_url="http://169.254.170.2") {
     container_relative <- Sys.getenv(ENV_CONTAINER_CREDS)

--- a/R/aws.ec2metadata-package.R
+++ b/R/aws.ec2metadata-package.R
@@ -184,7 +184,7 @@ ENV_CONTAINER_CREDS <- "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
 #' @export
 is_ecs <- function() {
     container_relative <- Sys.getenv(ENV_CONTAINER_CREDS)
-    return(!is.null(container_relative))
+    return(!is.null(container_relative)&&(container_relative != ""))
 }
 
 #' @rdname ec2metadata

--- a/R/aws.ec2metadata-package.R
+++ b/R/aws.ec2metadata-package.R
@@ -93,6 +93,8 @@ instance_document <- function() {
 #' # Can also get ECS container metadata
 #' if (is_ecs()) {
 #'   # Get ECS role credentials
+#'   metadata$ecs_task_role()
+#'   # or
 #'   ecs_metadata()
 #' }
 #' }
@@ -175,7 +177,11 @@ metadata <- list(
     },
     partition = function(...) {
         get_instance_metadata(item = "meta-data/services/partition", ...)
+    },
+    ecs_task_role = function(...) {
+        ecs_metadata(...)
     }
+
 )
 
 ENV_CONTAINER_CREDS <- "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"

--- a/man/ec2metadata.Rd
+++ b/man/ec2metadata.Rd
@@ -22,6 +22,9 @@ is_ecs()
 
 ecs_metadata(base_url = "http://169.254.170.2")
 }
+\arguments{
+\item{base_url}{Base URL for querying instance metadata}
+}
 \value{
 \code{is_ec2()} and \code{is_ecs()} return a logical. Generally, all other functions will return a character string containing the requested information, otherwise a \code{NULL} if the response is empty. The \code{iam_role()} and \code{ecs_metadata()} functions return a list. An error will occur if, for some reason, the request otherwise fails.
 }

--- a/man/ec2metadata.Rd
+++ b/man/ec2metadata.Rd
@@ -20,16 +20,16 @@ metadata
 
 is_ecs()
 
-ecs_metadata()
+ecs_metadata(base_url = "http://169.254.170.2")
 }
 \value{
-\code{is_ec2} returns a logical. Generally, all other functions will return a character string containing the requested information, otherwise a \code{NULL} if the response is empty. The \code{iam_role()} function returns a list. An error will occur if, for some reason, the request otherwise fails.
+\code{is_ec2()} and \code{is_ecs()} return a logical. Generally, all other functions will return a character string containing the requested information, otherwise a \code{NULL} if the response is empty. The \code{iam_role()} and \code{ecs_metadata()} functions return a list. An error will occur if, for some reason, the request otherwise fails.
 }
 \description{
 Retrieve EC2 instance metadata from the instance
 }
 \details{
-\code{is_ec2} returns a logical for whether the current R session appears to be running in an EC2 instance.
+\code{is_ec2()} returns a logical for whether the current R session appears to be running in an EC2 instance. \code{is_ecs()} returns a logical for whether the current R session appears to be running in an ECS task container.
 
 \code{instance_document} returns a list containing values from the \href{http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html}{Instance Identity Document}, including the instance ID, AMI ID, region, availability zone, etc.
 

--- a/man/ec2metadata.Rd
+++ b/man/ec2metadata.Rd
@@ -10,7 +10,7 @@
 \alias{is_ecs}
 \alias{ecs_metadata}
 \title{Get EC2 Instance Metadata}
-\format{An object of class \code{list} of length 25.}
+\format{An object of class \code{list} of length 26.}
 \usage{
 is_ec2()
 
@@ -69,6 +69,8 @@ if (is_ec2()) {
 # Can also get ECS container metadata
 if (is_ecs()) {
   # Get ECS role credentials
+  metadata$ecs_task_role()
+  # or
   ecs_metadata()
 }
 }


### PR DESCRIPTION
Env variables in R can be empty strings when not set, not just NULL.

(I'm not sure if they can ever be null, but I've not checked all R versions)

Fixes #3 

Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/cloudyr/aws.ec2metadata/issues/new) first
 - [x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/cloudyr/aws.ec2metadata/blob/master/DESCRIPTION)
 - [x] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/cloudyr/aws.ec2metadata/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [x] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [x] add code or new test files to [`/tests`](https://github.com/cloudyr/aws.ec2metadata/tree/master/tests/testthat) for any new functionality or bug fix
 - [x] make sure `R CMD check` runs without error before submitting the PR

